### PR TITLE
Assorted `README.md` updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ We allow you to add YAML front matter to all files to specify versions more
 precisely:
 
 ```toml
+# ---
 # pkgx:
 #   dependencies:
 #     openssl.org: 1.1.1n
+# ---
 
 [package]
 name = "my cargo project"

--- a/README.md
+++ b/README.md
@@ -142,12 +142,10 @@ You can add your own environment variables if you like:
 # ---
 ```
 
-> [!CAUTION]
+> [!NOTE]
 >
-> The assignment of these variables are run through the shell, so you can do
-> stuff like `$(pwd)` if you like. Obviously, be careful with that—we don’t
-> sanitize the input. We will accept a PR to escape this by default or something
-> ∵ we agree this is maybe a bit insane.
+> The environment variable's value is sanitized, so expressions like
+> `MY_VAR: $(sudo rm -rf --no-preserve-root /)` will throw an error.
 
 ## `dev` & Editors
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ precisely:
 
 ```toml
 # pkgx:
-#   openssl.org: 1.1.1n
+#   dependencies:
+#     openssl.org: 1.1.1n
 
 [package]
 name = "my cargo project"
@@ -116,9 +117,11 @@ we read a special `pkgx` node:
 ```json
 {
   "pkgx": {
-    "openssl.org": "1.1.1n",
-    "deno": "^2",
-    "npm": null
+    "dependencies": {
+      "openssl.org": "1.1.1n",
+      "deno": "^2",
+      "npm": null
+    }
   }
 }
 ```
@@ -130,10 +133,13 @@ You can also make a `pkgx.yaml` file.
 You can add your own environment variables if you like:
 
 ```toml
+# ---
 # pkgx:
-#   openssl.org: 1.1.1n
-# env:
-#   MY_VAR: my-value
+#   dependencies:
+#     openssl.org: 1.1.1n
+#   env:
+#     MY_VAR: my-value
+# ---
 ```
 
 > [!CAUTION]

--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ name = "my cargo project"
 We allow more terse expressions including eg:
 
 ```toml
-# pkgx: openssl.org@1.1.1n deno^2 npm
+# ---
+# pkgx:
+#   dependencies: openssl.org@1.1.1n deno^2 npm
+# ---
 ```
 
 The major exception being json since it doesn’t support comments, in this case


### PR DESCRIPTION
This PR updates the various examples in `README.md` to reflect the need for a `dependencies` key under `pkgx` (per the test cases under `fixtures/`).  I was banging my head on my keyboard for a second wondering why a `pkgx.yaml` with

```yaml
pkgx:
  typst.app: 0.13.0
```

wasn't actually adding `typst` to my `$PATH` until I checked the [relevant test case](https://github.com/pkgxdev/dev/blob/main/fixtures/pkgx.yml) and noticed that the syntax changed to

```yaml
dependencies:
  typst.app: 0.13.0
```

Hopefully this'll spare folks some of that frustration :)

While I was at it, I noticed that the TOML test cases ([`Cargo.toml`](https://github.com/pkgxdev/dev/blob/main/fixtures/Cargo.toml), [`pixi.toml`](https://github.com/pkgxdev/dev/blob/main/fixtures/pixi.toml), the various variations on [`pyproject.toml`](https://github.com/pkgxdev/dev/blob/main/fixtures/pyproject.toml/poetry-yaml-fm/pyproject.toml)) specify `# ---` fences around the frontmatter, so that's now reflected in the `README.md` examples as well.

I also removed the warning about command substitutions in environment variables, since those are no longer possible as of [e73e559](https://github.com/pkgxdev/pkgx/commit/e73e559548579643852d713e49ccda2c7e16dedf) ([#841](https://github.com/pkgxdev/pkgx/issues/841), [#842](https://github.com/pkgxdev/pkgx/issues/842)).  Tested both `BAD_ENV: $(pwd)` and `BAD_ENV: \`pwd\`` to confirm that both still throw errors (though it'd probably be a good idea to have `dev` throw a specific "don't try running commands" error in both cases).

EDIT: also updated the "one-liner" example, addressing [#22](https://github.com/pkgxdev/dev/issues/22) as far as `README.md` goes.