### PR TITLE
Console log `actived` -> `activated`

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -137,7 +137,7 @@ if (parsedArgs.help) {
             "dev.pkgx.activated",
           ).touch();
           console.log(
-            "%cactived",
+            "%cactivated",
             "color: green",
             pkgs.map(utils.pkg.str).join(" "),
           );


### PR DESCRIPTION
The spelling in the code didn't match README and I figured the README is correct