### PR TITLE
Fix error when directly changing into subdirectory of a devenv folder

### DIFF
--- a/src/shellcode().ts
+++ b/src/shellcode().ts
@@ -15,7 +15,7 @@ _pkgx_chpwd_hook() {
     dir="$PWD"
     while [ "$dir" != / -a "$dir" != . ]; do
       if [ -f "${datadir()}/$dir/dev.pkgx.activated" ]; then
-        eval "$(${dev_cmd})" "$dir"
+        eval "$(${dev_cmd} "$dir")"
         break
       fi
       dir="$(dirname "$dir")"


### PR DESCRIPTION
dev 1.8.1
zsh 5.9 (x86_64-apple-darwin22.0)

When changing directly into a subdirectory of a `devenv` folder from outside (e.g., `cd project/subdir`), the following error occurs:

```
no devenv detected
(eval):1: permission denied: /Users/.../project
```

This happens because the `devenv` root directory wasn’t correctly passed to the `dev` command, which is required for proper initialization in such cases.

This PR fixes the issue by ensuring the correct `devenv` folder is passed, even when entering subdirectories directly.
