### PR TITLE
Add local guide for running and testing a local fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,54 @@ same as `dev` does in your terminal.
 We use `deno`, so either install that or—you know—type `dev`.
 
 Edit [./src/sniff.ts](src/sniff.ts) to add new dev types.
+
+### Running your fork locally
+
+`./app.ts` is a `deno` script with a shebang, so once you’ve cloned the repo you
+can invoke it directly:
+
+```sh
+$ ./app.ts --version
+dev 0.0.0+dev
+```
+
+To test changes as your daily-driver `dev` you need to make the shellcode it
+generates embed _your_ local script. Two gotchas to be aware of:
+
+1. **Symlinking `app.ts` directly breaks `deno.json` resolution.** Deno looks
+   for `deno.json` next to the script path it’s actually invoked as, and doesn’t
+   follow symlinks. Use a thin shell wrapper instead:
+
+   ```sh
+   cat > ~/.local/bin/dev <<EOF
+   #!/bin/sh
+   exec $(pwd)/app.ts "\$@"
+   EOF
+   chmod +x ~/.local/bin/dev
+   ```
+
+2. **The shellcode embeds the path to `dev` at generation time** by searching
+   `$PATH`. So `~/.local/bin` needs to be ahead of any other `dev` install
+   _before_ shell init runs `eval "$(dev --shellcode)"`.
+
+   In your `~/.zshrc` (or `~/.bashrc`), prepend `~/.local/bin` to `PATH` before
+   the `dev` integration line:
+
+   ```sh
+   export PATH="$HOME/.local/bin:$PATH"
+   eval "$(dev --shellcode)"
+   ```
+
+   (If you’re already integrated via `dev integrate`, that line will already
+   exist, just add the `export PATH=…` above it)
+
+Open a fresh shell and verify the hook is wired to your local script:
+
+```zsh
+functions _pkgx_chpwd_hook | grep eval
+# expect: eval "$(/Users/you/.local/bin/dev "$dir")"
+```
+
+If you see the path to your wrapper, you’re running your fork end-to-end.
+Reverting is a `rm ~/.local/bin/dev` and removing the line(s) from your shell
+rc.


### PR DESCRIPTION
## Summary

- **What changed:** Adds a "Running your fork locally" subsection under
  Contributing in `README.md`, walking through the two steps
  needed to make a clone of this repo serve as your daily-driver `dev`. It's just a soft suggestion I would've found useful as a `dev` user, feel free to close if undesired.
- **Why:** `app.ts` runs directly via its shebang, but two gotchas trip up
  contributors trying to test changes end-to-end: (1) symlinking `app.ts`
  breaks Deno's `deno.json` resolution because Deno doesn't follow symlinks
  to find its config file, so a thin shell wrapper is needed; (2) the
  shellcode embeds the `dev` binary path by searching `$PATH` at generation
  time, so the wrapper has to win that lookup over any other installed `dev`
  (e.g. from `pkgm` or Homebrew).

## AI Intent

- **Prompt or task statement:** While debugging an unrelated issue, author wanted to run a local fork of `dev` to validate
  [pkgxdev/dev#61](https://github.com/pkgxdev/dev/pull/61) in their daily
  shell environment. The setup wasn't obvious from the existing README, so once
  worked out, the author asked the assistant to capture the procedure as a
  README addition so future contributors don't re-derive it.
- **Scope of AI-assisted changes:** Drafted the new subsection's prose,
  shell snippets, and the verification command. Author tested each step in
  their own environment and reviewed the final wording.

## Risk Assessment

- **Risk level:** low, documentation-only change.
- **Primary risks:** 
- **Compatibility impact:** None.

## Rollback Plan

- **Revert path:** Revert the commit.
- **Forward-fix path (if revert is not possible):** 

## Validation

- **Local checks run:** Each shell snippet was executed by the author
  during the prior debugging session and produced the expected results
  (wrapper script created with correct content via the heredoc, hook body
  embedded the local path, `grep eval` returned the expected line). Markdown
  rendering reviewed locally.
- **CI checks expected:** The change should be CI-neutral.

## Internal/Public Boundary Check

- [x] No internal-only data, private URLs, secrets, or private runbooks were
      added.